### PR TITLE
Improve Restart REPL icon UX in sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,10 @@
       },
       {
         "command": "haskellrun.restartRepl",
-        "title": "Haskell Run: Restart REPL"
-      },
+        "title": "Restart REPL",
+        "category": "Haskell Run",
+        "icon": "$(refresh)"
+     },
       {
         "command": "haskellrun.clearRepl",
         "title": "Haskell Run: Clear REPL"


### PR DESCRIPTION
Fixes #7
@midhunann 
The Restart REPL action in the Haskell Functions sidebar was rendering as large text. This change updates the command configuration to use a VS Code codicon instead, resulting in a cleaner and more consistent sidebar UI.

### Changes
- Added a codicon (`refresh`) to the Restart REPL command
- Simplified the command title and moved the extension name to the category

This is a configuration-only change in `package.json`.